### PR TITLE
Add DBD::Pg via cpanm to get version 2.19.3 instead of 2.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,6 +455,7 @@ done-host/pkgs: done-host/apt-get-update
 	# install unpackaged Perl modules
 	[ -e setup/bin/cpanm ] || (curl -L https://raw.github.com/miyagawa/cpanminus/master/cpanm >| setup/bin/cpanm && chmod +x setup/bin/cpanm)
 	sudo setup/bin/cpanm Getopt::Complete
+	sudo setup/bin/cpanm DBD::Pg # 2.19.3 
 	touch $@
 
 done-host/git-checkouts:

--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,8 @@ done-host/pkgs: done-host/apt-get-update
 	# install unpackaged Perl modules
 	[ -e setup/bin/cpanm ] || (curl -L https://raw.github.com/miyagawa/cpanminus/master/cpanm >| setup/bin/cpanm && chmod +x setup/bin/cpanm)
 	sudo setup/bin/cpanm Getopt::Complete
-	sudo setup/bin/cpanm DBD::Pg # 2.19.3 
+	sudo setup/bin/cpanm DBD::Pg # 2.19.3
+	sudo setup/bin/cpanm Set::IntervalTree
 	touch $@
 
 done-host/git-checkouts:


### PR DESCRIPTION
This will get around the explicit check for a version of DBD::Pg.
